### PR TITLE
implement get_last_block to avoid calculating difficulty when syncing blockchain

### DIFF
--- a/denaro/manager.py
+++ b/denaro/manager.py
@@ -77,7 +77,7 @@ async def get_last_block() -> dict:
     database = Database.instance
     async with database.pool.acquire() as connection:
         last_block = await connection.fetchrow(
-            "SELECT * FROM blocks ORDER BY id DESC LIMIT 1") or []
+            "SELECT * FROM blocks ORDER BY id DESC LIMIT 1") or list()
     return dict(last_block)
 
 

--- a/denaro/manager.py
+++ b/denaro/manager.py
@@ -73,6 +73,13 @@ async def calculate_difficulty() -> Tuple[Decimal, dict]:
 
     return last_block['difficulty'], last_block
 
+async def get_last_block() -> dict:
+    database = Database.instance
+    async with database.pool.acquire() as connection:
+        last_block = await connection.fetchrow(
+            "SELECT * FROM blocks ORDER BY id DESC LIMIT 1") or []
+    return dict(last_block)
+
 
 async def get_difficulty() -> Tuple[Decimal, dict]:
     if Manager.difficulty is None:

--- a/denaro/node/main.py
+++ b/denaro/node/main.py
@@ -11,7 +11,8 @@ from starlette.requests import Request
 
 from denaro.helpers import timestamp, sha256
 from denaro.manager import create_block, get_difficulty, Manager, get_transactions_merkle_tree, check_block_is_valid, \
-    split_block_content, calculate_difficulty, clear_pending_transactions, block_to_bytes
+    split_block_content, calculate_difficulty, clear_pending_transactions, \
+    block_to_bytes, get_last_block
 from denaro.node.nodes_manager import NodesManager
 from denaro.transactions import Transaction, CoinbaseTransaction
 from denaro import Database
@@ -89,7 +90,7 @@ async def sync_blockchain(node_url: str = None):
             return
         node_url = nodes[0]
     node_url = node_url.strip('/')
-    _, last_block = await calculate_difficulty()
+    last_block = await get_last_block()
     last_block_hash = last_block['hash'] if 'hash' in last_block else (30_06_2005).to_bytes(32, ENDIAN).hex()
     limit = 1000
     while True:


### PR DESCRIPTION
Syncing blockchain doesn't require any calculation of difficulty, it is better just to get last block and return it