### PR TITLE
No need to call datetime.replace for datetime.now(timezone.utc)

### DIFF
--- a/denaro/helpers.py
+++ b/denaro/helpers.py
@@ -33,7 +33,7 @@ def get_json(obj):
 
 
 def timestamp():
-    return int(datetime.now(timezone.utc).replace(tzinfo=timezone.utc).timestamp())
+    return int(datetime.now(timezone.utc).timestamp())
 
 
 def sha256(message: Union[str, bytes]):


### PR DESCRIPTION
datetime.now(timezone.utc) already has the timezone set to UTC, so calling replace(tzinfo=timezone.utc) is redundant